### PR TITLE
Rotating screen now reloads images properly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 22
         versionCode 5
-        versionName '0.9.1'
+        versionName '0.9.2'
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/ecchilon/sadpanda/imageviewer/ScreenSlidePagerAdapter.java
+++ b/app/src/main/java/com/ecchilon/sadpanda/imageviewer/ScreenSlidePagerAdapter.java
@@ -12,28 +12,28 @@ import com.ecchilon.sadpanda.overview.GalleryEntry;
 public class ScreenSlidePagerAdapter extends FragmentStatePagerAdapter {
 
 	private final ImageLoader loader;
-    private final GalleryEntry entry;
-    private final Bundle arguments;
+	private final GalleryEntry entry;
+	private final Bundle arguments;
 
 	public ScreenSlidePagerAdapter(FragmentManager fm, ImageLoader loader, GalleryEntry entry, Bundle arguments) {
 		super(fm);
 
-        this.loader = loader;
-        this.entry = entry;
-        this.arguments= arguments;
-    }
+		this.loader = loader;
+		this.entry = entry;
+		this.arguments = arguments;
+	}
 
-    @Override
-    public Fragment getItem(int position) {
-        ScreenSlidePageFragment frag = new ScreenSlidePageFragment();
-        frag.setArguments(arguments);
+	@Override
+	public Fragment getItem(int position) {
+		ScreenSlidePageFragment frag = new ScreenSlidePageFragment();
+		frag.setArguments(arguments);
 
-        loader.getImage(position+1, frag);
-        return frag;
-    }
+		loader.getImage(position + 1, frag);
+		return frag;
+	}
 
-    @Override
-    public int getCount() {
-        return entry.getFileCount();
-    }
+	@Override
+	public int getCount() {
+		return entry.getFileCount();
+	}
 }


### PR DESCRIPTION
Because mImageEntry was never reset when the state was being restored,
the images never loaded properly after any loss of state, most
noticeably when rotating a screen.